### PR TITLE
Update deployment-3-autoscaling.yaml

### DIFF
--- a/Lesson-09-Deployments/deployment-3-autoscaling.yaml
+++ b/Lesson-09-Deployments/deployment-3-autoscaling.yaml
@@ -28,13 +28,13 @@ spec:
             - containerPort: 80
 
 ---
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: my-autoscaling
 spec:
   scaleTargetRef:
-    apiVersion: apps/v2beta1v1
+    apiVersion: apps/v1
     kind: Deployment
     name: my-web-deployment-autoscaling
   minReplicas: 2
@@ -43,8 +43,12 @@ spec:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: 70
+      target:
+        type: Utilization
+        averageUtilization: 70
   - type: Resource
     resource:
       name: memory
-      targetAverageUtilization: 80
+      target:
+        type: Utilization
+        averageUtilization: 80


### PR DESCRIPTION
The file is updated for today, since the old example displays the error when applying: 'error: resource mapping not found for name: "my-autoscaling" namespace: "" from "deployment-3-autoscaling.yaml": no matches for kind "HorizontalPodAutoscaler " in version "autoscaling/v2beta1" ensure CRDs are installed first'

https://cloud.google.com/kubernetes-engine/docs/how-to/horizontal-pod-autoscaling